### PR TITLE
Fix incorrect configuration of diktat inputs on root project

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 11
-          distribution: zulu
+          distribution: temurin
       - name: Cache konan
         uses: actions/cache@v3
         with:
@@ -70,7 +70,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 11
-          distribution: zulu
+          distribution: temurin
       - name: Cache konan
         uses: actions/cache@v3
         with:

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 11
-          distribution: zulu
+          distribution: temurin
       - uses: gradle/gradle-build-action@v2
         with:
           gradle-version: wrapper

--- a/.github/workflows/diktat.yml
+++ b/.github/workflows/diktat.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 11
-          distribution: zulu
+          distribution: temurin
       - uses: gradle/gradle-build-action@v2
         with:
           gradle-version: wrapper

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 11
-          distribution: zulu
+          distribution: temurin
       - name: Status git before
         run: git status
       - uses: burrunan/gradle-cache-action@v1

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -6,7 +6,6 @@ object Versions {
         const val ktlintLink = "https://github.com/pinterest/ktlint/releases/download/$ktlint/ktlint"
         const val diktat = "1.0.2"
         const val diktatLink = "https://github.com/saveourtool/diKTat/releases/download/v$diktat/diktat-$diktat.jar"
-
         const val oldKtlint = "0.39.0"
         const val oldKtlintLink = "https://github.com/pinterest/ktlint/releases/download/$oldKtlint/ktlint"
         const val oldDiktat = "1.0.0-rc.2"

--- a/buildSrc/src/main/kotlin/com/saveourtool/save/buildutils/DiktatConfiguration.kt
+++ b/buildSrc/src/main/kotlin/com/saveourtool/save/buildutils/DiktatConfiguration.kt
@@ -27,10 +27,10 @@ fun Project.configureDiktat() {
                     "buildSrc/**/*.kts",
                     "*.kts"
                 )
-                exclude("$rootDir/build", "$rootDir/buildSrc/build")
+                exclude("build", "buildSrc/build")
             } else {
                 include("src/**/*.kt", "*.kts", "src/**/*.kts")
-                exclude("$projectDir/build/**")
+                exclude("build/**")
             }
         }
     }

--- a/buildSrc/src/main/kotlin/com/saveourtool/save/buildutils/DiktatConfiguration.kt
+++ b/buildSrc/src/main/kotlin/com/saveourtool/save/buildutils/DiktatConfiguration.kt
@@ -23,9 +23,9 @@ fun Project.configureDiktat() {
         inputs {
             if (path == rootProject.path) {
                 include(
-                    "$rootDir/buildSrc/src/**/*.kt",
-                    "$rootDir/buildSrc/**/*.kts",
-                    "$rootDir/*.kts"
+                    "buildSrc/src/**/*.kt",
+                    "buildSrc/**/*.kts",
+                    "*.kts"
                 )
                 exclude("$rootDir/build", "$rootDir/buildSrc/build")
             } else {

--- a/buildSrc/src/main/kotlin/com/saveourtool/save/buildutils/JacocoConfiguration.kt
+++ b/buildSrc/src/main/kotlin/com/saveourtool/save/buildutils/JacocoConfiguration.kt
@@ -1,3 +1,7 @@
+/**
+ * Configure JaCoCo for code coverage calculation
+ */
+
 package com.saveourtool.save.buildutils
 
 import org.gradle.api.Project
@@ -7,8 +11,8 @@ import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.getValue
-import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.register
 import org.gradle.testing.jacoco.plugins.JacocoPlugin
 import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
@@ -26,7 +30,7 @@ fun Project.configureJacoco() {
         toolVersion = "0.8.7"
     }
 
-    val kotlin = extensions.getByType<KotlinMultiplatformExtension>()
+    val kotlin: KotlinMultiplatformExtension = extensions.getByType()
     val jvmTestTask by tasks.named<Test>("jvmTest") {
         configure<JacocoTaskExtension> {
             // this is needed to generate jacoco/jvmTest.exec

--- a/buildSrc/src/main/kotlin/com/saveourtool/save/buildutils/PublishingConfiguration.kt
+++ b/buildSrc/src/main/kotlin/com/saveourtool/save/buildutils/PublishingConfiguration.kt
@@ -25,7 +25,8 @@ import org.gradle.plugins.signing.SigningPlugin
 @Suppress(
     "MISSING_KDOC_ON_FUNCTION",
     "MISSING_KDOC_TOP_LEVEL",
-    "TOO_LONG_FUNCTION")
+    "TOO_LONG_FUNCTION"
+)
 fun Project.configurePublishing() {
     // If present, set properties from env variables. If any are absent, release will fail.
     System.getenv("OSSRH_USERNAME")?.let {

--- a/buildSrc/src/main/kotlin/com/saveourtool/save/generation/Generation.kt
+++ b/buildSrc/src/main/kotlin/com/saveourtool/save/generation/Generation.kt
@@ -45,7 +45,8 @@ private val autoGenerationComment =
 @Suppress(
     "USE_DATA_CLASS",
     "MISSING_KDOC_CLASS_ELEMENTS",
-    "KDOC_NO_CLASS_BODY_PROPERTIES_IN_HEADER")
+    "KDOC_NO_CLASS_BODY_PROPERTIES_IN_HEADER"
+)
 class Option {
     lateinit var argType: String
     lateinit var kotlinType: String


### PR DESCRIPTION
* Fix incorrect configuration of diktat inputs on root project: use relative paths for PatternFilterable
* Switch JDK for Github Actions: zulu -> temurin