### PR TITLE
save-cli: Precision and recall

### DIFF
--- a/save-common/src/commonMain/kotlin/com/saveourtool/save/core/result/DebugInfo.kt
+++ b/save-common/src/commonMain/kotlin/com/saveourtool/save/core/result/DebugInfo.kt
@@ -24,15 +24,15 @@ data class DebugInfo(
 )
 
 /**
- * @property missing number of missing warnings
- * @property match number of match warnings
- * @property expected number of expected warnings
- * @property unexpected number of unexpected warnings
+ * @property unmatched number of unmatched checks/validations (warnings) in test (false negative results)
+ * @property matched number of matched checks/validations (warnings) in test (true positive results)
+ * @property expected number of al checks/validations (warnings) in test (unmatched + matched)
+ * @property unexpected number of matched, but unexpected checks/validations (warnings) in test (false positive results)
  */
 @Serializable
 data class CountWarnings(
-    val missing: Int,
-    val match: Int,
+    val unmatched: Int,
+    val matched: Int,
     val expected: Int,
     val unexpected: Int,
 )

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/com/saveourtool/save/plugin/warn/utils/ResultsChecker.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/com/saveourtool/save/plugin/warn/utils/ResultsChecker.kt
@@ -41,8 +41,8 @@ class ResultsChecker(
         val unexpectedWarnings = actualWarnings - actualMatchedWithExpectedWarnings
 
         val countWarnings = CountWarnings(
-            missing = missingWarnings.size,
-            match = expectedWarningsMatchedWithActual.size,
+            unmatched = missingWarnings.size,
+            matched = expectedWarningsMatchedWithActual.size,
             expected = expectedWarnings.size,
             unexpected = unexpectedWarnings.size
         )
@@ -50,19 +50,19 @@ class ResultsChecker(
         return when (missingWarnings.isEmpty() to unexpectedWarnings.isEmpty()) {
             false to true -> Fail(
                 "$MISSING $missingWarnings",
-                "$MISSING (${countWarnings.missing}). $MATCHED (${countWarnings.match})"
+                "$MISSING (${countWarnings.unmatched}). $MATCHED (${countWarnings.matched})"
             )
             false to false -> createFailFromDoubleMiss(missingWarnings, unexpectedWarnings, expectedWarningsMatchedWithActual)
-            true to true -> Pass("$ALL_EXPECTED (${countWarnings.match})")
+            true to true -> Pass("$ALL_EXPECTED (${countWarnings.matched})")
             true to false -> if (warnPluginConfig.exactWarningsMatch == false) {
                 Pass(
                     "$UNEXPECTED $unexpectedWarnings",
-                    "$UNEXPECTED (${countWarnings.unexpected}). $MATCHED (${countWarnings.match})"
+                    "$UNEXPECTED (${countWarnings.unexpected}). $MATCHED (${countWarnings.matched})"
                 )
             } else {
                 Fail(
                     "$UNEXPECTED $unexpectedWarnings",
-                    "$UNEXPECTED (${countWarnings.unexpected}). $MATCHED (${countWarnings.match})"
+                    "$UNEXPECTED (${countWarnings.unexpected}). $MATCHED (${countWarnings.matched})"
                 )
             }
             else -> Fail("N/A", "N/A")


### PR DESCRIPTION
### What's done:
- renamed match to matched
- renamed missing to unmatched

it's part of https://github.com/saveourtool/save-cloud/issues/514