### PR TITLE
`sarif-actual` example: set root logger's logging level for Diktat to INFO using logback.xml

### DIFF
--- a/examples/kotlin-diktat/logback.xml
+++ b/examples/kotlin-diktat/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/examples/kotlin-diktat/sarif-actual/save.toml
+++ b/examples/kotlin-diktat/sarif-actual/save.toml
@@ -3,9 +3,7 @@
     description = "Test warnings discovered by diKTat, reading expected warnings from SARIF file"
     suiteName = "Only Warnings: with SARIF format"
     expectedWarningsPattern = "// ;warn:?(.*):(\\d+):? ?(.+)?"
-    execCmd = "java -jar ktlint --disabled_rules=standard -R diktat.jar"
-
-
+    execCmd = "java -Dlogback.configurationFile=logback.xml -jar ktlint --disabled_rules=standard -R diktat.jar"
 
 [warn]
     execFlags = "--reporter=sarif"


### PR DESCRIPTION
This is a workaround for tests until https://github.com/saveourtool/diktat/issues/1394 is addressed, see https://github.com/saveourtool/save-cli/issues/401#issuecomment-1161843347 for description of the problem. By setting default logger level to INFO we effectively suppress everything that is not SARIF report in process's stdout and save-cli can parse it correctly.

Using additional file to configure logging might look like too harsh requirement to be able to run tests using SAVE, but I think we are simply asking to separate output streams of the process: SARIF goes into stdout, everything else users should be able to switch off, redirect to `/dev/null` or to stderr

Closes #401