### PR TITLE
Migrate from `gradle-cache-action` to `gradle/gradle-build-action`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     steps:
       - uses: actions/checkout@v3
@@ -24,6 +24,8 @@ jobs:
       - name: Cache konan
         uses: actions/cache@v3
         with:
+          # [@actions/glob](https://github.com/actions/toolkit/tree/main/packages/glob) is used to match paths
+          # It should correctly expand `~` on every OS.
           path: ~/.konan
           key: ${{ runner.os }}-gradle-konan-1.7.0
           restore-keys: |
@@ -53,42 +55,3 @@ jobs:
         with:
           flags: unittests
           fail_ci_if_error: false # optional (default = false)
-
-  build_and_test_win:
-    name: Build and test on Win
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: 11
-          distribution: temurin
-      - name: Cache konan
-        uses: actions/cache@v3
-        with:
-          path: 'C:\Users\runneradmin\.konan'
-          key: Windows-gradle-konan-1.7.0
-          restore-keys: |
-            Windows-gradle-konan-1.7.0
-      - uses: gradle/gradle-build-action@v2
-        with:
-          gradle-version: wrapper
-          arguments: |
-            build
-            -x detekt
-            -Porg.gradle.caching=true
-            -Pdetekt.multiplatform.disabled=true
-            -PdisableRedundantTargets=true
-            -PenabledExecutables=debug
-            -PgprUser=${{ github.actor }}
-            -PgprKey=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload gradle reports
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: gradle-reports-windows-latest
-          path: '**/build/reports/'
-          retention-days: 1

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,23 +28,18 @@ jobs:
           key: ${{ runner.os }}-gradle-konan-1.7.0
           restore-keys: |
             ${{ runner.os }}-gradle-konan-1.7.0
-      - uses: burrunan/gradle-cache-action@v1
+      - uses: gradle/gradle-build-action@v2
         with:
           gradle-version: wrapper
-          # additional files to calculate key for dependency cache
-          gradle-dependencies-cache-key: |
-            buildSrc/**/Versions.kt
-          # Note: https://github.com/burrunan/gradle-cache-action/issues/42 can possible break this
           arguments: |
             build
             -x detekt
-          properties: |
-            org.gradle.caching=true
-            detekt.multiplatform.disabled=true
-            disableRedundantTargets=true
-            enabledExecutables=debug
-            gprUser=${{ github.actor }}
-            gprKey=${{ secrets.GITHUB_TOKEN }}
+            -Porg.gradle.caching=true
+            -Pdetekt.multiplatform.disabled=true
+            -PdisableRedundantTargets=true
+            -PenabledExecutables=debug
+            -PgprUser=${{ github.actor }}
+            -PgprKey=${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload gradle reports
         if: ${{ always() }}
@@ -78,23 +73,18 @@ jobs:
           key: Windows-gradle-konan-1.7.0
           restore-keys: |
             Windows-gradle-konan-1.7.0
-      - uses: burrunan/gradle-cache-action@v1
+      - uses: gradle/gradle-build-action@v2
         with:
           gradle-version: wrapper
-          # additional files to calculate key for dependency cache
-          gradle-dependencies-cache-key: |
-            buildSrc/**/Versions.kt
-          # Note: https://github.com/burrunan/gradle-cache-action/issues/42 can possibly break this
           arguments: |
             build
             -x detekt
-          properties: |
-            org.gradle.caching=true
-            detekt.multiplatform.disabled=true
-            disableRedundantTargets=true
-            enabledExecutables=debug
-            gprUser=${{ github.actor }}
-            gprKey=${{ secrets.GITHUB_TOKEN }}
+            -Porg.gradle.caching=true
+            -Pdetekt.multiplatform.disabled=true
+            -PdisableRedundantTargets=true
+            -PenabledExecutables=debug
+            -PgprUser=${{ github.actor }}
+            -PgprKey=${{ secrets.GITHUB_TOKEN }}
       - name: Upload gradle reports
         if: ${{ always() }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -2,13 +2,12 @@ name: Run deteKT
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
 
 jobs:
   detekt_check:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11

--- a/.github/workflows/diktat.yml
+++ b/.github/workflows/diktat.yml
@@ -2,15 +2,12 @@ name: Run diKTat
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
 
 jobs:
   diktat_check:
-    runs-on: ubuntu-20.04
-    env:
-      GRADLE_OPTS: -Dorg.gradle.daemon=false
-
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,19 +32,34 @@ jobs:
           distribution: temurin
       - name: Status git before
         run: git status
-      - uses: burrunan/gradle-cache-action@v1
-        with:
-          gradle-version: wrapper
-      # Until https://github.com/burrunan/gradle-cache-action/issues/42 is addressed, gradle should be run as a separate step
       - name: gradle release from tag
         # if workflow is triggered after push of a tag, deploy full release
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        run: ./gradlew --build-cache -Prelease -PgprUser=${{ github.actor }} -PgprKey=${{ secrets.GITHUB_TOKEN }} linkReleaseExecutableMultiplatform publishToSonatype closeSonatypeStagingRepository
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: wrapper
+          arguments: |
+            linkReleaseExecutableMultiplatform
+            publishToSonatype
+            closeSonatypeStagingRepository
+            -Prelease
+            --build-cache
+            -PgprUser=${{ github.actor }}
+            -PgprKey=${{ secrets.GITHUB_TOKEN }}
       - name: gradle snapshot from branch
         # if workflow is triggered after push to a branch, deploy snapshot
         if: ${{ startsWith(github.ref, 'refs/heads/') }}
-        run: ./gradlew --build-cache -Prelease -PgprUser=${{ github.actor }} -PgprKey=${{ secrets.GITHUB_TOKEN }} -Preckon.stage=snapshot linkReleaseExecutableMultiplatform publishToSonatype
-        shell: bash
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: wrapper
+          arguments: |
+            linkReleaseExecutableMultiplatform
+            publishToSonatype
+            -Preckon.stage=snapshot
+            -Prelease
+            --build-cache
+            -PgprUser=${{ github.actor }}
+            -PgprKey=${{ secrets.GITHUB_TOKEN }}
       - name: Status git after
         if: ${{ always() }}
         run: git status


### PR DESCRIPTION
* Migrate from `gradle-cache-action` to `gradle/gradle-build-action`
* Merge jobs for Windows and non-Windows runners
* Cleanup workflows: fix default branch name, remove redundant gradle option