### PR TITLE
set test location relative path relative to original test path

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,10 +5,6 @@ import com.saveourtool.save.buildutils.configureVersioning
 import com.saveourtool.save.buildutils.createDetektTask
 import com.saveourtool.save.buildutils.installGitHooks
 
-plugins {
-    id("com.cdsap.talaiot.plugin.base") version "1.4.2"
-}
-
 configureVersioning()
 
 configureDiktat()
@@ -16,9 +12,3 @@ createDetektTask()
 installGitHooks()
 
 configurePublishing()
-
-talaiot {
-    publishers {
-        timelinePublisher = true
-    }
-}


### PR DESCRIPTION
to be in sync with save-cloud logic