### PR TITLE
Set Gradle property to enable Kotlin XML test report

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,29 +36,15 @@ jobs:
       - uses: gradle/gradle-build-action@v2
         with:
           gradle-version: wrapper
+          # The `--continue` flag is necessary so that Gradle keeps going after the 1st test failure.
+          # By default, when test for all MPP targets are executed, Kotlin Gradle Plugin generates a single aggregated HTML report.
+          # Property `kotlin.tests.individualTaskReports` enables individual Junit-style XML reports.
+          # See org.jetbrains.kotlin.gradle.testing.internal.KotlinTestReport.
           arguments: |
             build
-            -x detekt
-            -Porg.gradle.caching=true
-            -Pdetekt.multiplatform.disabled=true
-            -PdisableRedundantTargets=true
-            -PenabledExecutables=debug
-            -PgprUser=${{ github.actor }}
-            -PgprKey=${{ secrets.GITHUB_TOKEN }}
-
-        # For some reason, running `gradle build jvmTest` produces no JUnit reports,
-        # so these two targets should be separated into separate steps.
-      - name: gradle jvmTest
-        uses: gradle/gradle-build-action@v2
-        if: ${{ always() }}
-        with:
-          gradle-version: wrapper
-          # The `--continue` flag is necessary so that Gradle keeps going after the 1st test failure.
-          # The `jvmTest` target is needed for JUnit-style XML reports.
-          arguments: |
             --continue
-            jvmTest
             -x detekt
+            -Pkotlin.tests.individualTaskReports=true
             -Porg.gradle.caching=true
             -Pdetekt.multiplatform.disabled=true
             -PdisableRedundantTargets=true


### PR DESCRIPTION
In #421 we introduced a separate step to re-run JVM tests, because by default when tests for all targets are executed, Kotlin Gradle Plugin generates only a single HTML report. This behavior can be turned off, however.

There is a more-or-less detailed discussion at https://youtrack.jetbrains.com/issue/KT-32608/Create-JUnit-XML-result-file-in-multiplatform-gradle-build