### PR TITLE
Allow PR's to succeed even if authored by non-collaborators

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,6 +17,13 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
 
+    # A possible workaround for <https://github.com/dorny/test-reporter/issues/168>.
+    permissions:
+      checks: write
+      contents: write
+      pull-requests: write
+      statuses: write
+
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11
@@ -63,6 +70,11 @@ jobs:
           # Comma-separated values.
           path: "**/build/test-results/*/TEST-*.xml"
           reporter: java-junit
+        # Ignore the "Resource not accessible by integration" error when a PR
+        # originates from a non-collaborator. This is
+        # <https://github.com/dorny/test-reporter/issues/168> which may be
+        # potentially fixed with <https://github.com/dorny/test-reporter/pull/174>.
+        continue-on-error: true
 
       - name: Upload test results
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
### What's done:

 * This tries to work around dorny/test-reporter#168.