### PR TITLE
Introduced `not applicable` counter for FixPlugin

### DIFF
--- a/save-common/src/commonMain/kotlin/com/saveourtool/save/core/result/DebugInfo.kt
+++ b/save-common/src/commonMain/kotlin/com/saveourtool/save/core/result/DebugInfo.kt
@@ -37,7 +37,7 @@ data class CountWarnings(
     val unexpected: Int,
 ) {
     companion object {
-        const val NOT_APPLICABLE_COUNTER: Int = -99
+        private const val NOT_APPLICABLE_COUNTER: Int = -99
 
         /**
          * [CountWarnings] is not applicable for current run
@@ -48,5 +48,11 @@ data class CountWarnings(
             NOT_APPLICABLE_COUNTER,
             NOT_APPLICABLE_COUNTER
         )
+
+        /**
+         * @param counter value of counter to be checked
+         * @return true if provided value has value which means that current counter is not applicable (FixPlugin for example), otherwise -- false
+         */
+        fun isNotApplicable(counter: Int): Boolean = NOT_APPLICABLE_COUNTER == counter
     }
 }

--- a/save-common/src/commonMain/kotlin/com/saveourtool/save/core/result/DebugInfo.kt
+++ b/save-common/src/commonMain/kotlin/com/saveourtool/save/core/result/DebugInfo.kt
@@ -35,4 +35,18 @@ data class CountWarnings(
     val matched: Int,
     val expected: Int,
     val unexpected: Int,
-)
+) {
+    companion object {
+        const val NOT_APPLICABLE_COUNTER: Int = -99
+
+        /**
+         * [CountWarnings] is not applicable for current run
+         */
+        val notApplicable = CountWarnings(
+            NOT_APPLICABLE_COUNTER,
+            NOT_APPLICABLE_COUNTER,
+            NOT_APPLICABLE_COUNTER,
+            NOT_APPLICABLE_COUNTER
+        )
+    }
+}

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPlugin.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPlugin.kt
@@ -13,6 +13,7 @@ import com.saveourtool.save.core.plugin.ExtraFlagsExtractor
 import com.saveourtool.save.core.plugin.GeneralConfig
 import com.saveourtool.save.core.plugin.Plugin
 import com.saveourtool.save.core.plugin.resolvePlaceholdersFrom
+import com.saveourtool.save.core.result.CountWarnings
 import com.saveourtool.save.core.result.DebugInfo
 import com.saveourtool.save.core.result.Fail
 import com.saveourtool.save.core.result.Pass
@@ -123,7 +124,8 @@ class FixPlugin(
                             execCmd,
                             stdout.filter { it.contains(testCopy.name) }.joinToString("\n"),
                             stderr.filter { it.contains(testCopy.name) }.joinToString("\n"),
-                            null
+                            null,
+                            CountWarnings.notApplicable,
                         )
                     )
                 }
@@ -139,7 +141,7 @@ class FixPlugin(
         TestResult(
             it,
             Fail(ex.describe(), ex.describe()),
-            DebugInfo(execCmd, null, ex.message, null)
+            DebugInfo(execCmd, null, ex.message, null, CountWarnings.notApplicable)
         )
     }
 

--- a/save-plugins/fix-plugin/src/commonNonJsTest/kotlin/com/saveourtool/save/plugins/fix/FixPluginTest.kt
+++ b/save-plugins/fix-plugin/src/commonNonJsTest/kotlin/com/saveourtool/save/plugins/fix/FixPluginTest.kt
@@ -62,6 +62,7 @@ class FixPluginTest {
         assertEquals("Test2Expected.java", pairs.single().second.name)
     }
 
+    @Suppress("TOO_LONG_FUNCTION")
     @Test
     fun `should calculate diff of discovered files`() {
         val config = fs.createFile(tmpDir / "save.toml")

--- a/save-plugins/fix-plugin/src/commonNonJsTest/kotlin/com/saveourtool/save/plugins/fix/FixPluginTest.kt
+++ b/save-plugins/fix-plugin/src/commonNonJsTest/kotlin/com/saveourtool/save/plugins/fix/FixPluginTest.kt
@@ -5,6 +5,7 @@ import com.saveourtool.save.core.config.TestConfig
 import com.saveourtool.save.core.files.createFile
 import com.saveourtool.save.core.files.fs
 import com.saveourtool.save.core.plugin.GeneralConfig
+import com.saveourtool.save.core.result.CountWarnings
 import com.saveourtool.save.core.result.DebugInfo
 import com.saveourtool.save.core.result.Pass
 import com.saveourtool.save.core.result.TestResult
@@ -90,8 +91,14 @@ class FixPluginTest {
         assertEquals(1, results.size, "Size of results should equal number of pairs")
         val testResult = results.single()
         assertEquals(
-            TestResult(FixPlugin.FixTestFiles(testFile, expectedFile), Pass(null), DebugInfo(
-                testResult.debugInfo?.execCmd, testResult.debugInfo?.stdout, testResult.debugInfo?.stderr, null)
+            TestResult(FixPlugin.FixTestFiles(testFile, expectedFile), Pass(null),
+                DebugInfo(
+                    testResult.debugInfo?.execCmd,
+                    testResult.debugInfo?.stdout,
+                    testResult.debugInfo?.stderr,
+                    null,
+                    CountWarnings.notApplicable,
+                )
             ),
             testResult
         )


### PR DESCRIPTION
### What's done:
* added a new constant for CountWarnings

It closes https://github.com/saveourtool/save-cloud/issues/1039