### PR TITLE
Backward compatibility

### DIFF
--- a/save-core/src/commonNonJsMain/kotlin/com/saveourtool/save/core/files/ConfigDetector.kt
+++ b/save-core/src/commonNonJsMain/kotlin/com/saveourtool/save/core/files/ConfigDetector.kt
@@ -15,7 +15,7 @@ import okio.Path
  */
 class ConfigDetector(
     private val fs: FileSystem,
-    private val overridesPluginConfigs: List<PluginConfig>,
+    private val overridesPluginConfigs: List<PluginConfig> = emptyList(),
 ) {
     /**
      * Try to create SAVE config file from [testConfig].


### PR DESCRIPTION
### What's done:
A default value for `overridesPluginConfigs` in ConfigDetector, this field breaks preprocessor