### PR TITLE
Adapt FixPlugin for library for applying of SARIF fix patches

### DIFF
--- a/save-common/src/commonMain/kotlin/com/saveourtool/save/core/config/FixFormats.kt
+++ b/save-common/src/commonMain/kotlin/com/saveourtool/save/core/config/FixFormats.kt
@@ -5,10 +5,10 @@
 package com.saveourtool.save.core.config
 
 /**
- * Possible formats of actual (i.e. produces by the tool) warnings
+ * Possible formats of actual set of fixes, provided by user
  */
 enum class ActualFixFormat {
-    PLAIN,
+    IN_PLACE,
     SARIF,
     ;
 }

--- a/save-common/src/commonMain/kotlin/com/saveourtool/save/core/config/FixFormats.kt
+++ b/save-common/src/commonMain/kotlin/com/saveourtool/save/core/config/FixFormats.kt
@@ -1,0 +1,14 @@
+/**
+ * Classes that describe format of expected and actual fixes
+ */
+
+package com.saveourtool.save.core.config
+
+/**
+ * Possible formats of actual (i.e. produces by the tool) warnings
+ */
+enum class ActualFixFormat {
+    PLAIN,
+    SARIF,
+    ;
+}

--- a/save-common/src/commonMain/kotlin/com/saveourtool/save/core/config/FixFormats.kt
+++ b/save-common/src/commonMain/kotlin/com/saveourtool/save/core/config/FixFormats.kt
@@ -2,7 +2,7 @@
  * Classes that describe format of expected and actual fixes
  */
 
-@file:Suppress("FILE_NAME_MATCH_CLASS")
+@file:Suppress("FILE_NAME_MATCH_CLASS", "MatchingDeclarationName")
 
 package com.saveourtool.save.core.config
 

--- a/save-common/src/commonMain/kotlin/com/saveourtool/save/core/config/FixFormats.kt
+++ b/save-common/src/commonMain/kotlin/com/saveourtool/save/core/config/FixFormats.kt
@@ -2,6 +2,8 @@
  * Classes that describe format of expected and actual fixes
  */
 
+@file:Suppress("FILE_NAME_MATCH_CLASS")
+
 package com.saveourtool.save.core.config
 
 /**

--- a/save-plugins/fix-and-warn-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fixandwarn/FixAndWarnPlugin.kt
+++ b/save-plugins/fix-and-warn-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fixandwarn/FixAndWarnPlugin.kt
@@ -92,18 +92,7 @@ class FixAndWarnPlugin(
         }
 
         // Fill back original data with warnings
-        filesAndTheirWarningsMap.forEach { (filePath, warningsList) ->
-            val fileData = fs.readLines(filePath) as MutableList
-            // Append warnings into appropriate place
-            warningsList.forEach { (line, warningMsg) ->
-                fileData.add(line, warningMsg)
-            }
-            fs.write(filePath) {
-                fileData.forEach {
-                    write((it + "\n").encodeToByteArray())
-                }
-            }
-        }
+        restoreWarningsIntoExpectedFiles(filesAndTheirWarningsMap)
 
         // TODO: If we receive just one command for execution, and want to avoid extra executions
         // TODO: then warn plugin should look at the fix plugin output for actual warnings, and not execute command one more time.
@@ -136,7 +125,7 @@ class FixAndWarnPlugin(
     /**
      * Remove warnings from the given files, which satisfy pattern from <warn> plugin and save data about warnings, which were deleted
      *
-     * @files files to be modified
+     * @param files files to be modified
      *
      * @return map of files and theirs list of warnings
      */
@@ -155,6 +144,26 @@ class FixAndWarnPlugin(
             writeDataWithoutWarnings(file, filesAndTheirWarningsMap, fileDataWithoutWarnings)
         }
         return filesAndTheirWarningsMap
+    }
+
+    /**
+     * Remove warnings into the given files, which were deleted in aim to provide clear fix changes by FixPlugin
+     *
+     * @param filesAndTheirWarningsMap map of files with corresponding warnings list, which need to be restored
+     */
+    private fun restoreWarningsIntoExpectedFiles(filesAndTheirWarningsMap: MutableMap<Path, WarningsList>) {
+        filesAndTheirWarningsMap.forEach { (filePath, warningsList) ->
+            val fileData = fs.readLines(filePath) as MutableList
+            // Append warnings into appropriate place
+            warningsList.forEach { (line, warningMsg) ->
+                fileData.add(line, warningMsg)
+            }
+            fs.write(filePath) {
+                fileData.forEach {
+                    write((it + "\n").encodeToByteArray())
+                }
+            }
+        }
     }
 
     private fun writeDataWithoutWarnings(

--- a/save-plugins/fix-and-warn-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fixandwarn/FixAndWarnPlugin.kt
+++ b/save-plugins/fix-and-warn-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fixandwarn/FixAndWarnPlugin.kt
@@ -126,7 +126,6 @@ class FixAndWarnPlugin(
      * Remove warnings from the given files, which satisfy pattern from <warn> plugin and save data about warnings, which were deleted
      *
      * @param files files to be modified
-     *
      * @return map of files and theirs list of warnings
      */
     private fun removeWarningsFromExpectedFiles(files: Sequence<Path>): MutableMap<Path, WarningsList> {

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPlugin.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPlugin.kt
@@ -106,10 +106,6 @@ class FixPlugin(
                 val execCmd = "$execCmdWithoutFlags $execFlagsAdjusted"
                 val time = generalConfig.timeOutMillis!!.times(pathMap.size)
 
-                if (fixPluginConfig.actualFixFormat == ActualFixFormat.SARIF) {
-                    // TODO: Apply fixes from sarif file on `testCopyNames` here
-                }
-
                 val executionResult = try {
                     pb.exec(execCmd, testConfig.getRootConfig().directory.toString(), redirectTo, time)
                 } catch (ex: ProcessTimeoutException) {
@@ -121,6 +117,13 @@ class FixPlugin(
 
                 val stdout = executionResult.stdout
                 val stderr = executionResult.stderr
+
+                // In this case fixes weren't performed by tool into the test files directly,
+                // instead, there was created sarif file with list of fixes, which we will apply ourselves
+                if (fixPluginConfig.actualFixFormat == ActualFixFormat.SARIF) {
+                    // TODO: Apply fixes from sarif file on `testCopyNames` here
+                    // applySarifFixesToFiles(fixPluginConfig.actualFixSarifFileName, testCopyNames)
+                }
 
                 pathCopyMap.map { (testCopy, expected) ->
                     val fixedLines = fs.readLines(testCopy)

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPlugin.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPlugin.kt
@@ -62,8 +62,8 @@ class FixPlugin(
         newTag = { _, start -> if (start) "<" else ">" },
     )
 
-    // fixme: consider refactoring under https://github.com/saveourtool/save/issues/156
-    // fixme: should not be common for a class instance during https://github.com/saveourtool/save/issues/28
+    // fixme: consider refactoring under https://github.com/saveourtool/save-cli/issues/156
+    // fixme: should not be common for a class instance during https://github.com/saveourtool/save-cli/issues/28
     private var tmpDirectory: Path? = null
     private lateinit var extraFlagsExtractor: ExtraFlagsExtractor
 
@@ -94,7 +94,7 @@ class FixPlugin(
 
                 val pathMap = chunk.map { it.test to it.expected }
                 val pathCopyMap = pathMap.map { (test, expected) ->
-                    createTestFile(test, generalConfig, fixPluginConfig) to expected
+                    createCopyOfTestFile(test, generalConfig, fixPluginConfig) to expected
                 }
                 val testCopyNames =
                         pathCopyMap.joinToString(separator = batchSeparator) { (testCopy, _) -> testCopy.toString() }
@@ -160,7 +160,7 @@ class FixPlugin(
                 }
             }
 
-    private fun createTestFile(
+    private fun createCopyOfTestFile(
         path: Path,
         generalConfig: GeneralConfig,
         fixPluginConfig: FixPluginConfig,

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPlugin.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPlugin.kt
@@ -1,5 +1,6 @@
 package com.saveourtool.save.plugins.fix
 
+import com.saveourtool.save.core.config.ActualFixFormat
 import com.saveourtool.save.core.config.TestConfig
 import com.saveourtool.save.core.files.createFile
 import com.saveourtool.save.core.files.createRelativePathToTheRoot
@@ -67,10 +68,6 @@ class FixPlugin(
     private var tmpDirectory: Path? = null
     private lateinit var extraFlagsExtractor: ExtraFlagsExtractor
 
-    // TODO:
-    // 1) Add expectedFixFormat: file or sarif
-    // 2) If sarif -- apply fixes from it to copy of test file
-    // 3) Compare with expected file
     @Suppress("TOO_LONG_FUNCTION", "LongMethod")
     override fun handleFiles(files: Sequence<TestFiles>): Sequence<TestResult> {
         testConfig.validateAndSetDefaults()
@@ -108,6 +105,10 @@ class FixPlugin(
                 val execCmdWithoutFlags = generalConfig.execCmd
                 val execCmd = "$execCmdWithoutFlags $execFlagsAdjusted"
                 val time = generalConfig.timeOutMillis!!.times(pathMap.size)
+
+                if (fixPluginConfig.actualFixFormat == ActualFixFormat.SARIF) {
+                    // TODO: Apply fixes from sarif file on `testCopyNames` here
+                }
 
                 val executionResult = try {
                     pb.exec(execCmd, testConfig.getRootConfig().directory.toString(), redirectTo, time)

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPlugin.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPlugin.kt
@@ -67,6 +67,10 @@ class FixPlugin(
     private var tmpDirectory: Path? = null
     private lateinit var extraFlagsExtractor: ExtraFlagsExtractor
 
+    // TODO:
+    // 1) Add expectedFixFormat: file or sarif
+    // 2) If sarif -- apply fixes from it to copy of test file
+    // 3) Compare with expected file
     @Suppress("TOO_LONG_FUNCTION", "LongMethod")
     override fun handleFiles(files: Sequence<TestFiles>): Sequence<TestResult> {
         testConfig.validateAndSetDefaults()

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPluginConfig.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPluginConfig.kt
@@ -31,6 +31,7 @@ data class FixPluginConfig(
     val resourceNameExpectedSuffix: String? = null,
     val ignoreLines: MutableList<String>? = null,
     val actualFixFormat: ActualFixFormat? = null,
+    val actualFixSarifFileName: String? = null,
 ) : PluginConfig {
     override val type = TestConfigSections.FIX
 
@@ -66,6 +67,7 @@ data class FixPluginConfig(
                 this.ignoreLines?.let { other.ignoreLines.union(this.ignoreLines) } ?: other.ignoreLines
             }?.toMutableList() ?: this.ignoreLines,
             this.actualFixFormat ?: other.actualFixFormat
+            this.actualFixSarifFileName ?: other.actualFixSarifFileName
         ).also {
             it.configLocation = this.configLocation
         }
@@ -77,7 +79,8 @@ data class FixPluginConfig(
         resourceNameTest,
         resourceNameExpected,
         ignoreLines,
-        actualFixFormat ?: ActualFixFormat.PLAIN
+        actualFixFormat ?: ActualFixFormat.IN_PLACE,
+        actualFixSarifFileName ?: "save-fixes.sarif",
     ).also {
         it.configLocation = this.configLocation
     }

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPluginConfig.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPluginConfig.kt
@@ -23,6 +23,8 @@ import kotlinx.serialization.UseSerializers
  * @property resourceNameTestSuffix suffix name of the test file.
  * @property resourceNameExpectedSuffix suffix name of the expected file.
  * @property ignoreLines mutable list of patterns that later will be used to filter lines in test file
+ * @property actualFixFormat format for type for fixes: they could be done in place or provided via Sarif file
+ * @property actualFixSarifFileName name of sarif file with list of fixes, that were made by tool
  */
 @Serializable
 data class FixPluginConfig(
@@ -66,7 +68,7 @@ data class FixPluginConfig(
             other.ignoreLines?.let {
                 this.ignoreLines?.let { other.ignoreLines.union(this.ignoreLines) } ?: other.ignoreLines
             }?.toMutableList() ?: this.ignoreLines,
-            this.actualFixFormat ?: other.actualFixFormat
+            this.actualFixFormat ?: other.actualFixFormat,
             this.actualFixSarifFileName ?: other.actualFixSarifFileName
         ).also {
             it.configLocation = this.configLocation

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPluginConfig.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPluginConfig.kt
@@ -2,6 +2,7 @@
 
 package com.saveourtool.save.plugins.fix
 
+import com.saveourtool.save.core.config.ActualFixFormat
 import com.saveourtool.save.core.config.TestConfigSections
 import com.saveourtool.save.core.plugin.PluginConfig
 import com.saveourtool.save.core.utils.RegexSerializer
@@ -28,7 +29,8 @@ data class FixPluginConfig(
     val execFlags: String? = null,
     val resourceNameTestSuffix: String? = null,
     val resourceNameExpectedSuffix: String? = null,
-    val ignoreLines: MutableList<String>? = null
+    val ignoreLines: MutableList<String>? = null,
+    val actualFixFormat: ActualFixFormat? = null,
 ) : PluginConfig {
     override val type = TestConfigSections.FIX
 
@@ -62,7 +64,8 @@ data class FixPluginConfig(
             this.resourceNameExpectedSuffix ?: other.resourceNameExpectedSuffix,
             other.ignoreLines?.let {
                 this.ignoreLines?.let { other.ignoreLines.union(this.ignoreLines) } ?: other.ignoreLines
-            }?.toMutableList() ?: this.ignoreLines
+            }?.toMutableList() ?: this.ignoreLines,
+            this.actualFixFormat ?: other.actualFixFormat
         ).also {
             it.configLocation = this.configLocation
         }
@@ -73,7 +76,8 @@ data class FixPluginConfig(
         execFlags ?: "",
         resourceNameTest,
         resourceNameExpected,
-        ignoreLines
+        ignoreLines,
+        actualFixFormat ?: ActualFixFormat.PLAIN
     ).also {
         it.configLocation = this.configLocation
     }


### PR DESCRIPTION
### What's done:
* Adapt FixPlugin for library for applying of SARIF fix patches


FixAndWarnPlugin use FixPlugin for fixing test files and comparing with expected, which are released of warnings at the moment of FixPlugin start, so there is no need to make changes in `FixAndWarnPlugin`