### PR TITLE
Fixes in SARIF mode

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,3 +12,11 @@ createDetektTask()
 installGitHooks()
 // publishing to maven central
 configurePublishing()
+
+allprojects {
+    configurations.all {
+        // if SNAPSHOT dependencies are used, refresh them periodically
+        resolutionStrategy.cacheDynamicVersionsFor(10, TimeUnit.MINUTES)
+        resolutionStrategy.cacheChangingModulesFor(10, TimeUnit.MINUTES)
+    }
+}

--- a/examples/kotlin-diktat/fix/sarif/save.toml
+++ b/examples/kotlin-diktat/fix/sarif/save.toml
@@ -3,8 +3,6 @@
     description = "SARIF fix objects: Smoke tests for diktat"
     suiteName = "SARIF fix objects - Autofix"
 
-# FixMe: Until https://github.com/saveourtool/sarif-utils/issues/23
-# FixMe: compare only by names, but should by full paths
-#[fix]
-    #actualFixFormat = "SARIF"
-    #actualFixSarifFileName = "save-fixes.sarif"
+[fix]
+    actualFixFormat = "SARIF"
+    actualFixSarifFileName = "save-fixes.sarif"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ multiplatform-diff = "0.4.0"
 kotlinpoet = "1.12.0"
 kotest = "5.5.4"
 sarif4k = "0.3.0"
-sarif-utils = "0.1.0"
+sarif-utils = "0.2.0-SNAPSHOT"
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/save-core/src/commonNonJsTest/kotlin/com/saveourtool/save/core/test/utils/TestUtilsCommon.kt
+++ b/save-core/src/commonNonJsTest/kotlin/com/saveourtool/save/core/test/utils/TestUtilsCommon.kt
@@ -53,7 +53,7 @@ fun runTestsWithDiktat(
     ).let(overrideProperties)
 
     // logger is not set from save properties without a config reader, need to set it explicitly
-    logType.set(LogType.ALL)
+    logType.set(LogType.WARN)
     // In this test we need to merge with emulated empty save.properties file in aim to use default values,
     // since initially all fields are null
     val save = Save(saveProperties, fs)

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPlugin.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPlugin.kt
@@ -209,9 +209,7 @@ class FixPlugin(
         // modify existing map, replace test copies to fixed test copies
         val fixedTestCopyToExpectedFilesMap = testCopyToExpectedFilesMap.toMutableList().map { (testCopy, expected) ->
             val fixedTestCopy = fixedFiles.first {
-                // FixMe: Until https://github.com/saveourtool/sarif-utils/issues/23
-                // FixMe: compare only by names, but should by full paths
-                it.name == testCopy.name
+                isComparingTestAndCopy(it, testCopy, fixPluginConfig.actualFixFormat!!)
             }
             fixedTestCopy to expected
         }
@@ -270,11 +268,11 @@ class FixPlugin(
             testCopyPathAfterTmpDir
         } else {
             // in sarif mode in comes with testRootPath, since it was copied by sarif library itself
-            // trim testRootPath
+            // so trim testRootPath
             testCopyPathAfterTmpDir
                 .relativeTo(testConfig.getRootConfig().directory)
                 // seems, that relativeTo not indefinitely add DIRECTORY_SEPARATOR: sometimes / , sometimes \
-                // into the final path, so we use such strange hack in aim to apply toPath, which will set
+                // into the path, so we use such strange hack in aim to apply toPath, which will set
                 // all separators correctly
                 .toString()
                 .toPath()

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPlugin.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPlugin.kt
@@ -129,8 +129,7 @@ class FixPlugin(
                     adjustedTestCopyToExpectedFilesMap,
                     execCmd,
                     stdout,
-                    stderr,
-                    fixPluginConfig.actualFixFormat!!
+                    stderr
                 )
             }
             .flatten()
@@ -210,10 +209,7 @@ class FixPlugin(
         val fixedTestCopyToExpectedFilesMap = testCopyToExpectedFilesMap.toMutableList().map { (testCopy, expected) ->
             val fixedTestCopy = fixedFiles.first {
                 isComparingTestAndCopy(
-                    it.relativeTo(FileSystem.SYSTEM_TEMPORARY_DIRECTORY)
-                        .toString()
-                        .substringAfter(Path.DIRECTORY_SEPARATOR)
-                        .toPath(),
+                    it,
                     testCopy
                 )
             }
@@ -238,8 +234,7 @@ class FixPlugin(
         testCopyToExpectedFilesMap: List<PathPair>,
         execCmd: String,
         stdout: List<String>,
-        stderr: List<String>,
-        fixFormat: ActualFixFormat
+        stderr: List<String>
     ): List<TestResult> = testCopyToExpectedFilesMap.map { (testCopy, expected) ->
         val fixedLines = fs.readLines(testCopy)
         val expectedLines = fs.readLines(expected)

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPlugin.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPlugin.kt
@@ -226,7 +226,6 @@ class FixPlugin(
      * @param execCmd execution command for debug info
      * @param stdout std out of executed tool, if any
      * @param stderr std err of executed tool, if any
-     * @param fixFormat fix format
      * @return list of the test results
      */
     private fun buildTestResultsForChunk(
@@ -268,9 +267,9 @@ class FixPlugin(
         val tmpDirAdjusted = FileSystem.SYSTEM_TEMPORARY_DIRECTORY.toString().replaceSeparators()
         return if (currentPathAdjusted.startsWith(tmpDirAdjusted)) {
             currentPathAdjusted
-                // remove tmpDir
+                // trim tmpDir
                 .substringAfter("$tmpDirAdjusted/")
-                // remove FixPlugin dir
+                // trim tmp FixPlugin dir
                 .substringAfter("/")
                 .toPath()
         } else {
@@ -280,7 +279,10 @@ class FixPlugin(
 
     private fun Path.trimTestRootPath(): Path {
         val currentPathAdjusted = this.toString().replaceSeparators()
-        val testRootPathAdjusted = testConfig.getRootConfig().directory.toString().replaceSeparators()
+        val testRootPathAdjusted = testConfig.getRootConfig()
+            .directory
+            .toString()
+            .replaceSeparators()
         return if (currentPathAdjusted.startsWith(testRootPathAdjusted)) {
             currentPathAdjusted
                 .substringAfter("$testRootPathAdjusted/")
@@ -290,9 +292,7 @@ class FixPlugin(
         }
     }
 
-    private fun String.replaceSeparators(): String {
-        return this.replace("\\", "/")
-    }
+    private fun String.replaceSeparators(): String = this.replace("\\", "/")
 
     private fun failTestResult(
         chunk: List<FixTestFiles>,

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPlugin.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPlugin.kt
@@ -257,8 +257,8 @@ class FixPlugin(
         test: Path,
         testCopy: Path,
     ): Boolean {
-        val testPath = test.trimTmpDir().trimTestRootPath()
-        val testCopyPath = testCopy.trimTmpDir().trimTestRootPath()
+        val testPath = test.trimTmpDir().trimTestRootPath().replaceSeparators()
+        val testCopyPath = testCopy.trimTmpDir().trimTestRootPath().replaceSeparators()
         return testCopyPath.compareTo(testPath) == 0
     }
 
@@ -293,6 +293,8 @@ class FixPlugin(
     }
 
     private fun String.replaceSeparators(): String = this.replace("\\", "/")
+
+    private fun Path.replaceSeparators(): Path = this.toString().replaceSeparators().toPath()
 
     private fun failTestResult(
         chunk: List<FixTestFiles>,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,10 @@ include("save-common-test")
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
+        // add sonatype repository
+        maven {
+            url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+        }
     }
 }
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
### What's done:
* Rework the logic of comparing the `test` file and its copy
* Enable test for SARIF mode in fix plugin