### PR TITLE
Execute tool in sarif mode before report checking

### DIFF
--- a/examples/kotlin-diktat/sarif-actual/save-warnings-actual.sarif
+++ b/examples/kotlin-diktat/sarif-actual/save-warnings-actual.sarif
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "originalUriBaseIds": {
+        "%SRCROOT%": {
+          "uri": "file://D:/projects/"
+        }
+      },
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src\\kotlin\\EnumValueSnakeCaseTest.kt",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "startColumn": 5,
+                  "startLine": 18
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "[ENUM_VALUE] enum values should be in selected UPPER_CASE snake/PascalCase format: NAme_MYa_sayR_"
+          },
+          "ruleId": "diktat-ruleset:identifier-naming"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "downloadUri": "https://github.com/pinterest/ktlint/releases/tag/0.42.0",
+          "fullName": "ktlint",
+          "informationUri": "https://github.com/pinterest/ktlint/",
+          "language": "en",
+          "name": "ktlint",
+          "organization": "pinterest",
+          "rules": [
+          ],
+          "semanticVersion": "0.42.0",
+          "version": "0.42.0"
+        }
+      }
+    }
+  ]
+}

--- a/examples/kotlin-diktat/sarif-actual/save-warnings-actual.sarif
+++ b/examples/kotlin-diktat/sarif-actual/save-warnings-actual.sarif
@@ -19,16 +19,121 @@
                   "uriBaseId": "%SRCROOT%"
                 },
                 "region": {
-                  "startColumn": 5,
-                  "startLine": 18
+                  "startColumn": 35,
+                  "startLine": 6
                 }
               }
             }
           ],
           "message": {
-            "text": "[ENUM_VALUE] enum values should be in selected UPPER_CASE snake/PascalCase format: NAme_MYa_sayR_"
+            "text": "[WRONG_DECLARATIONS_ORDER] declarations of constants and enum members should be sorted alphabetically: enum entries order is incorrect (diktat-ruleset:abp-sort-rule)"
           },
-          "ruleId": "diktat-ruleset:identifier-naming"
+          "ruleId": "diktat-ruleset:abp-sort-rule"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src\\kotlin\\EnumValueSnakeCaseTest.kt",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "startColumn": 5,
+                  "startLine": 10
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "[ENUMS_SEPARATED] enum is incorrectly formatted: enums must end with semicolon (diktat-ruleset:abq-enum-separated)"
+          },
+          "ruleId": "diktat-ruleset:abq-enum-separated"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src\\kotlin\\EnumValueSnakeCaseTest.kt",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "startColumn": 5,
+                  "startLine": 8
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "[ENUM_VALUE] enum values should be in selected UPPER_CASE snake/PascalCase format: paSC_SAl_l (diktat-ruleset:aai-identifier-naming)"
+          },
+          "ruleId": "diktat-ruleset:aai-identifier-naming"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src\\kotlin\\EnumValueSnakeCaseTest.kt",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "startColumn": 5,
+                  "startLine": 11
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "[ENUM_VALUE] enum values should be in selected UPPER_CASE snake/PascalCase format: PascAsl_f (diktat-ruleset:aai-identifier-naming)"
+          },
+          "ruleId": "diktat-ruleset:aai-identifier-naming"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src\\kotlin\\EnumValueSnakeCaseTest.kt",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "startColumn": 5,
+                  "startLine": 10
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "[ENUMS_SEPARATED] enum is incorrectly formatted: last enum entry must end with a comma (diktat-ruleset:abq-enum-separated)"
+          },
+          "ruleId": "diktat-ruleset:abq-enum-separated"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src\\kotlin\\EnumValueSnakeCaseTest.kt",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "startColumn": 9,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "[PACKAGE_NAME_INCORRECT_PREFIX] package name should start from company's domain: com.saveourtool.save (diktat-ruleset:aah-package-naming)"
+          },
+          "ruleId": "diktat-ruleset:aah-package-naming"
         }
       ],
       "tool": {

--- a/examples/kotlin-diktat/sarif-actual/save.toml
+++ b/examples/kotlin-diktat/sarif-actual/save.toml
@@ -10,6 +10,9 @@
     # regular expression to detect tests
     testNameRegex = ".*Test.kt"
     actualWarningsFormat = "SARIF"
+    # by default, in SARIF mode, it's supposed, that tool will print sarif report into the stdout
+    # however, it also could be provided via file
+    # actualWarningsFileName = "save-warnings-actual.sarif"
     fileNameCaptureGroupOut = 1
     lineCaptureGroupOut = 2
     columnCaptureGroupOut = 3

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPlugin.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPlugin.kt
@@ -188,6 +188,7 @@ class FixPlugin(
      * @param testCopyToExpectedFilesMap list of paths to the copy of tests files, which will be replaced by modificated files
      * @return updated list of test files copies
      */
+    // TODO: support case, when sarif report is provided via stdout
     private fun applyFixesFromSarif(
         fixPluginConfig: FixPluginConfig,
         testsPaths: List<Path>,

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPlugin.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/com/saveourtool/save/plugins/fix/FixPlugin.kt
@@ -19,7 +19,6 @@ import com.saveourtool.save.core.result.DebugInfo
 import com.saveourtool.save.core.result.Fail
 import com.saveourtool.save.core.result.Pass
 import com.saveourtool.save.core.result.TestResult
-import com.saveourtool.save.core.utils.ExecutionResult
 import com.saveourtool.save.core.utils.PathSerializer
 import com.saveourtool.save.core.utils.ProcessExecutionException
 import com.saveourtool.save.core.utils.ProcessTimeoutException

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/com/saveourtool/save/plugin/warn/WarnPlugin.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/com/saveourtool/save/plugin/warn/WarnPlugin.kt
@@ -144,8 +144,7 @@ class WarnPlugin(
 
         val expectedWarningsMap = try {
             processExpectedWarnings(generalConfig, warnPluginConfig, originalPaths, copyPaths, workingDirectory)
-        }
-        catch (ex: SarifParsingException) {
+        } catch (ex: SarifParsingException) {
             return failTestResult(originalPaths, ex, execCmd)
         }
 
@@ -160,8 +159,7 @@ class WarnPlugin(
 
         val actualWarningsMap = try {
             processActualWarnings(executionResult, warnPluginConfig, originalPaths, workingDirectory)
-        }
-        catch (ex: SarifParsingException) {
+        } catch (ex: SarifParsingException) {
             return failTestResult(originalPaths, ex, execCmd)
         }
 

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/com/saveourtool/save/plugin/warn/WarnPlugin.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/com/saveourtool/save/plugin/warn/WarnPlugin.kt
@@ -229,15 +229,18 @@ class WarnPlugin(
         originalPaths: List<Path>,
         workingDirectory: Path,
     ): WarningMap {
-        val actualResult = if (warnPluginConfig.actualWarningsFormat == ActualWarningsFormat.SARIF) {
+        val actualResult = if (warnPluginConfig.actualWarningsFormat == ActualWarningsFormat.SARIF &&
+            warnPluginConfig.actualWarningsFileName != null) {
             // in this case, after tool execution, there was created sarif report, extract warnings from it,
             // not from stdout
             val sarif = calculatePathToSarifFile(
-                sarifFileName = warnPluginConfig.actualWarningsFileName!!,
+                sarifFileName = warnPluginConfig.actualWarningsFileName,
                 anchorTestFilePath = originalPaths.first()
             )
             ExecutionResult(executionResult.code, fs.readLines(sarif), executionResult.stderr)
         } else {
+            // Note: this case is applicable both for PLAIN and SARIF mode, but in the latter case, we suppose,
+            // that sarif report is provided in stdout of tool
             executionResult
         }
         return collectActualWarningsWithLineNumbers(actualResult, warnPluginConfig, workingDirectory)

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/com/saveourtool/save/plugin/warn/WarnPlugin.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/com/saveourtool/save/plugin/warn/WarnPlugin.kt
@@ -230,7 +230,7 @@ class WarnPlugin(
         workingDirectory: Path,
     ): WarningMap {
         val actualResult = if (warnPluginConfig.actualWarningsFormat == ActualWarningsFormat.SARIF &&
-            warnPluginConfig.actualWarningsFileName != null) {
+                warnPluginConfig.actualWarningsFileName != null) {
             // in this case, after tool execution, there was created sarif report, extract warnings from it,
             // not from stdout
             val sarif = calculatePathToSarifFile(

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/com/saveourtool/save/plugin/warn/WarnPluginConfig.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/com/saveourtool/save/plugin/warn/WarnPluginConfig.kt
@@ -161,8 +161,10 @@ data class WarnPluginConfig(
         requireValidPatternForRegexInWarning()
 
         val expectedWarningsFormat = expectedWarningsFormat ?: ExpectedWarningsFormat.IN_PLACE
+        val expectedWarningsFileName = expectedWarningsFileName ?: "save-warnings-expected.sarif"
+
         val actualWarningsFormat = actualWarningsFormat ?: ActualWarningsFormat.PLAIN
-        val expectedWarningsFileName = expectedWarningsFileName ?: "save-warnings.sarif"
+        val actualWarningsFileName = actualWarningsFileName ?: "save-warnings-actual.sarif"
 
         val newWarningTextHasLine = warningTextHasLine ?: true
         val newWarningTextHasColumn = warningTextHasColumn ?: true

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/com/saveourtool/save/plugin/warn/WarnPluginConfig.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/com/saveourtool/save/plugin/warn/WarnPluginConfig.kt
@@ -164,7 +164,9 @@ data class WarnPluginConfig(
         val expectedWarningsFileName = expectedWarningsFileName ?: "save-warnings-expected.sarif"
 
         val actualWarningsFormat = actualWarningsFormat ?: ActualWarningsFormat.PLAIN
-        val actualWarningsFileName = actualWarningsFileName ?: "save-warnings-actual.sarif"
+        // it could be null even, if actualWarningsFormat = sarif: in this case, we suppose, that tool will print
+        // sarif report into stdout
+        val actualWarningsFileName = actualWarningsFileName
 
         val newWarningTextHasLine = warningTextHasLine ?: true
         val newWarningTextHasColumn = warningTextHasColumn ?: true


### PR DESCRIPTION
### What's done:
* Execute tool before checking the sarif report, this logic allows:
  1) Support checking `.sarif` from stdout
  2) Rewrite existing sarif report, if `actual[Warnings|Fix]SarifFileName` was provided and something were changed in report

* Minor refactoring
* Add possible config for one of the test (however it's not required, since `save-cli` will look into stdout by default)

Part of https://github.com/saveourtool/save-cli/issues/497