### PR TITLE
Make `publish...` tasks depend on `sign...` tasks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
       - 'v*'
     branches:
       - main
+      # Fixme: temporary, for experiments
+      - bugfix/gradle-publishing
 env:
   GPG_SEC: ${{ secrets.PGP_SEC }}
   GPG_PASSWORD: ${{ secrets.PGP_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,6 @@ on:
       - 'v*'
     branches:
       - main
-      # Fixme: temporary, for experiments
-      - bugfix/gradle-publishing
 env:
   GPG_SEC: ${{ secrets.PGP_SEC }}
   GPG_PASSWORD: ${{ secrets.PGP_PASSWORD }}

--- a/buildSrc/src/main/kotlin/com/saveourtool/save/buildutils/PublishingConfiguration.kt
+++ b/buildSrc/src/main/kotlin/com/saveourtool/save/buildutils/PublishingConfiguration.kt
@@ -14,7 +14,7 @@ import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.extra
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.withType
@@ -85,7 +85,7 @@ fun Project.configurePublishing() {
 
 @Suppress("TOO_LONG_FUNCTION")
 private fun Project.configurePublications() {
-    val dokkaJar: Jar = tasks.create<Jar>("dokkaJar") {
+    val dokkaJarProvider = tasks.register<Jar>("dokkaJar") {
         group = "documentation"
         archiveClassifier.set("javadoc")
         from(tasks.findByName("dokkaHtml"))
@@ -95,7 +95,7 @@ private fun Project.configurePublications() {
             mavenLocal()
         }
         publications.withType<MavenPublication>().forEach { publication ->
-            publication.artifact(dokkaJar)
+            publication.artifact(dokkaJarProvider)
             publication.pom {
                 name.set(project.name)
                 description.set(project.description ?: project.name)


### PR DESCRIPTION
Successful run: https://github.com/saveourtool/save-cli/actions/runs/4241944409

All `publish...` tasks share Javadoc artifact (until we set up proper Javadoc generation), so this PR makes all of them dependent.

Closes #502